### PR TITLE
Implement CQRS command bus and enhance ResponseBase immutability

### DIFF
--- a/src/Rewardly.Application/Bus/CommandBus.cs
+++ b/src/Rewardly.Application/Bus/CommandBus.cs
@@ -15,13 +15,13 @@ public class CommandBus : ICommandBus
     {
         CommandExecutionContext? context = _resolver.Resolve(command);
 
-        return await ((dynamic)context.Handler).HandlerAsync((dynamic)command, cancellationToken);
+        return await ((dynamic)context.Handler).HandleAsync((dynamic)command, cancellationToken);
     }
 
     public async Task SendAsync(ICommand command, CancellationToken cancellationToken)
     {
         CommandExecutionContext? context = _resolver.Resolve(command);
 
-        await ((dynamic)context.Handler).HandlerAsync((dynamic)command, cancellationToken);
+        await ((dynamic)context.Handler).HandleAsync((dynamic)command, cancellationToken);
     }
 }

--- a/src/Rewardly.Application/Bus/CommandBus.cs
+++ b/src/Rewardly.Application/Bus/CommandBus.cs
@@ -1,0 +1,27 @@
+﻿using Rewardly.Application.Interfaces.Bus;
+
+namespace Rewardly.Application.Bus;
+
+public class CommandBus : ICommandBus
+{
+    private readonly ICommandHandlerResolver _resolver;
+
+    public CommandBus(ICommandHandlerResolver resolver)
+    {
+        _resolver = resolver;
+    }
+
+    public async Task<TResponse> SendAsync<TResponse>(ICommand<TResponse> command, CancellationToken cancellationToken)
+    {
+        CommandExecutionContext? context = _resolver.Resolve(command);
+
+        return await ((dynamic)context.Handler).HandlerAsync((dynamic)command, cancellationToken);
+    }
+
+    public async Task SendAsync(ICommand command, CancellationToken cancellationToken)
+    {
+        CommandExecutionContext? context = _resolver.Resolve(command);
+
+        await ((dynamic)context.Handler).HandlerAsync((dynamic)command, cancellationToken);
+    }
+}

--- a/src/Rewardly.Application/Bus/CommandExecutionContext.cs
+++ b/src/Rewardly.Application/Bus/CommandExecutionContext.cs
@@ -1,0 +1,19 @@
+﻿using Rewardly.Application.Interfaces.Bus;
+
+namespace Rewardly.Application.Bus;
+
+public sealed class CommandExecutionContext
+{
+    public ICommandBase Command { get; }
+    public object Handler { get; }
+    public Type CommandType { get; }
+    public Type HandlerType { get; }
+
+    public CommandExecutionContext(ICommandBase command, object handler, Type commandType, Type handlerType)
+    {
+        Command = command;
+        Handler = handler;
+        CommandType = commandType;
+        HandlerType = handlerType;
+    }
+}

--- a/src/Rewardly.Application/Bus/CommandHandlerResolver.cs
+++ b/src/Rewardly.Application/Bus/CommandHandlerResolver.cs
@@ -1,0 +1,37 @@
+﻿using Rewardly.Application.Interfaces.Bus;
+
+namespace Rewardly.Application.Bus;
+
+public class CommandHandlerResolver : ICommandHandlerResolver
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public CommandHandlerResolver(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public CommandExecutionContext Resolve(ICommand command)
+    {
+        Type? handlerType = typeof(ICommandHandler<,>).MakeGenericType(command.GetType());
+
+        return ResolveHandler(command, handlerType);
+    }
+
+    public CommandExecutionContext Resolve<TResponse>(ICommand<TResponse> command)
+    {
+        Type? handlerType = typeof(ICommandHandler<,>).MakeGenericType(command.GetType(), typeof(TResponse));
+
+        return ResolveHandler(command, handlerType);
+    }
+
+    private CommandExecutionContext ResolveHandler(ICommandBase command, Type handlerType) 
+    {
+        object? handler = _serviceProvider.GetService(handlerType);
+
+        if (handler is null)
+            throw new InvalidOperationException($"No handler registered for '{handlerType.Name}'.");
+
+        return new CommandExecutionContext(command, handler, command.GetType(), handlerType);
+    }
+}

--- a/src/Rewardly.Application/Commands/v1/Base/CommandBase.cs
+++ b/src/Rewardly.Application/Commands/v1/Base/CommandBase.cs
@@ -1,0 +1,9 @@
+﻿using Rewardly.Application.Interfaces.Bus;
+
+namespace Rewardly.Application.Commands.Base;
+
+public abstract class CommandBase<TResponse> : ICommand<TResponse>
+{
+    public Guid CorrelationId => Guid.NewGuid();
+    public DateTime CreatedAt => DateTime.UtcNow;
+}

--- a/src/Rewardly.Application/Commands/v1/Base/CommandBase.cs
+++ b/src/Rewardly.Application/Commands/v1/Base/CommandBase.cs
@@ -4,6 +4,6 @@ namespace Rewardly.Application.Commands.Base;
 
 public abstract class CommandBase<TResponse> : ICommand<TResponse>
 {
-    public Guid CorrelationId => Guid.NewGuid();
-    public DateTime CreatedAt => DateTime.UtcNow;
+    public Guid CorrelationId { get; } = Guid.NewGuid();
+    public DateTime CreatedAt { get; } = DateTime.UtcNow;
 }

--- a/src/Rewardly.Application/Interfaces/Bus/ICommand.cs
+++ b/src/Rewardly.Application/Interfaces/Bus/ICommand.cs
@@ -1,0 +1,27 @@
+﻿namespace Rewardly.Application.Interfaces.Bus;
+
+/// <summary>
+/// Define um comando que produz uma resposta tipada após o processamento.
+/// </summary>
+/// <typeparam name="TResponse">Tipo de resposta retornada pelo manipulador do comando.</typeparam>
+public interface ICommand<out TResponse> : ICommandBase { }
+
+/// <summary>
+/// Define um comando que não produz valor de retorno explícito.
+/// </summary>
+public interface ICommand : ICommandBase { }
+
+/// <summary>
+/// Reúne metadados comuns aplicáveis a todos os comandos da aplicação.
+/// </summary>
+public interface ICommandBase
+{
+    /// <summary>
+    /// Obtém o identificador de correlação para rastreamento ponta a ponta da requisição.
+    /// </summary>
+    Guid CorrelationId { get; }
+    /// <summary>
+    /// Obtém a data e hora de criação do comando.
+    /// </summary>
+    DateTime CreatedAt { get; }
+}

--- a/src/Rewardly.Application/Interfaces/Bus/ICommandBus.cs
+++ b/src/Rewardly.Application/Interfaces/Bus/ICommandBus.cs
@@ -1,0 +1,28 @@
+﻿namespace Rewardly.Application.Interfaces.Bus;
+
+/// <summary>
+/// Define o barramento responsável por encaminhar comandos aos respectivos manipuladores.
+/// </summary>
+public interface ICommandBus
+{
+    /// <summary>
+    /// Envia um comando sem retorno para o manipulador apropriado.
+    /// </summary>
+    /// <param name="command">Comando a ser processado.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Tarefa assíncrona que representa a conclusão do processamento.</returns>
+    Task SendAsync(
+        ICommand command, 
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Envia um comando com retorno tipado para o manipulador apropriado.
+    /// </summary>
+    /// <typeparam name="TResponse">Tipo da resposta esperada após o processamento do comando.</typeparam>
+    /// <param name="command">Comando a ser processado.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Resultado do processamento do comando.</returns>
+    Task<TResponse> SendAsync<TResponse>(
+        ICommand<TResponse> command,
+        CancellationToken cancellationToken);
+}

--- a/src/Rewardly.Application/Interfaces/Bus/ICommandHandler.cs
+++ b/src/Rewardly.Application/Interfaces/Bus/ICommandHandler.cs
@@ -1,0 +1,32 @@
+﻿namespace Rewardly.Application.Interfaces.Bus;
+
+/// <summary>
+/// Define o contrato para manipulação de comandos com retorno tipado.
+/// </summary>
+/// <typeparam name="TCommand">Tipo do comando processado pelo manipulador.</typeparam>
+/// <typeparam name="TResponse">Tipo da resposta gerada pelo processamento do comando.</typeparam>
+public interface ICommandHandler<in TCommand, TResponse> where TCommand : ICommand<TResponse>
+{
+    /// <summary>
+    /// Processa o comando informado e retorna a resposta correspondente.
+    /// </summary>
+    /// <param name="command">Comando a ser processado.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Resposta resultante do processamento do comando.</returns>
+    Task<TResponse> HandleAsync(TCommand command, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Define o contrato para manipulação de comandos sem retorno explícito.
+/// </summary>
+/// <typeparam name="TCommand">Tipo do comando processado pelo manipulador.</typeparam>
+public interface ICommandHandler<in TCommand> where TCommand : ICommand
+{
+    /// <summary>
+    /// Processa o comando informado sem produzir valor de retorno.
+    /// </summary>
+    /// <param name="command">Comando a ser processado.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Tarefa assíncrona que representa a conclusão do processamento.</returns>
+    Task HandleAsync(TCommand command, CancellationToken cancellationToken);
+}

--- a/src/Rewardly.Application/Interfaces/Bus/ICommandHandlerResolver.cs
+++ b/src/Rewardly.Application/Interfaces/Bus/ICommandHandlerResolver.cs
@@ -1,0 +1,24 @@
+﻿using Rewardly.Application.Bus;
+
+namespace Rewardly.Application.Interfaces.Bus;
+
+/// <summary>
+/// Define a resolução de contexto de execução para comandos e respectivos manipuladores.
+/// </summary>
+public interface ICommandHandlerResolver
+{
+    /// <summary>
+    /// Resolve o contexto de execução de um comando sem retorno explícito.
+    /// </summary>
+    /// <param name="command">Comando para o qual o contexto deverá ser resolvido.</param>
+    /// <returns>Contexto com informações necessárias para a execução do comando.</returns>
+    CommandExecutionContext Resolve(ICommand command);
+
+    /// <summary>
+    /// Resolve o contexto de execução de um comando com retorno tipado.
+    /// </summary>
+    /// <typeparam name="TResponse">Tipo de resposta associada ao comando.</typeparam>
+    /// <param name="command">Comando para o qual o contexto deverá ser resolvido.</param>
+    /// <returns>Contexto com informações necessárias para a execução do comando.</returns>
+    CommandExecutionContext Resolve<TResponse>(ICommand<TResponse> command);
+}

--- a/src/Rewardly.Application/IoC/ApplicationModule.cs
+++ b/src/Rewardly.Application/IoC/ApplicationModule.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Rewardly.Application.Bus;
+using Rewardly.Application.Interfaces.Bus;
 using Rewardly.Domain.Interfaces.v1;
 using Rewardly.Domain.Notifications.v1;
 
@@ -9,6 +11,8 @@ public static class ApplicationModule
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
         services.AddScoped<INotification, NotificationContext>();
+        services.AddScoped<ICommandBus, CommandBus>();
+        services.AddScoped<ICommandHandlerResolver, CommandHandlerResolver>();
 
         return services;
     }

--- a/src/Rewardly.Application/Responses/ResponseBase.cs
+++ b/src/Rewardly.Application/Responses/ResponseBase.cs
@@ -13,9 +13,9 @@ public class ResponseBase<T>
         Errors = errors ?? Array.Empty<string>();
     }
 
-    public static ResponseBase<T> Ok(T Data) 
-        => new(true, Data, null);
+    public static ResponseBase<T> Ok(T data) 
+        => new(true, data, null);
 
-    public static ResponseBase<T> Fail(params string[] Erros)
-        => new(false, default, Erros);
+    public static ResponseBase<T> Fail(params string[] erros)
+        => new(false, default, erros);
 }

--- a/src/Rewardly.Application/Responses/ResponseBase.cs
+++ b/src/Rewardly.Application/Responses/ResponseBase.cs
@@ -2,16 +2,16 @@
 
 public class ResponseBase<T>
 {
+    public bool Success { get; private set; }
+    public T? Data { get; private set; }
+    public IReadOnlyCollection<string> Errors { get; private set; }
+
     public ResponseBase(bool success, T? data, IReadOnlyCollection<string>? errors)
     {
         Success = success;
         Data = data;
         Errors = errors ?? Array.Empty<string>();
     }
-
-    public bool Success { get; private set; }
-    public T? Data { get; private set; }
-    public IReadOnlyCollection<string> Errors { get; private set; }
 
     public static ResponseBase<T> Ok(T Data) 
         => new(true, Data, null);

--- a/src/Rewardly.Application/Responses/ResponseBase.cs
+++ b/src/Rewardly.Application/Responses/ResponseBase.cs
@@ -2,8 +2,20 @@
 
 public class ResponseBase<T>
 {
-    public bool Success { get; init; }
-    public string? Message { get; init; }
-    public T? Data { get; init; }
-    public IEnumerable<string>? Errors { get; init; }
+    public ResponseBase(bool success, T? data, IReadOnlyCollection<string>? errors)
+    {
+        Success = success;
+        Data = data;
+        Errors = errors ?? Array.Empty<string>();
+    }
+
+    public bool Success { get; private set; }
+    public T? Data { get; private set; }
+    public IReadOnlyCollection<string> Errors { get; private set; }
+
+    public static ResponseBase<T> Ok(T Data) 
+        => new(true, Data, null);
+
+    public static ResponseBase<T> Fail(params string[] Erros)
+        => new(false, default, Erros);
 }

--- a/src/Rewardly.Domain/Interfaces/v1/IAggregateRoot.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/IAggregateRoot.cs
@@ -1,11 +1,32 @@
 ﻿namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Define o contrato base de uma raiz de agregado no contexto de DDD,
+/// incluindo identidade, versionamento e gestão de eventos não persistidos.
+/// </summary>
 public interface IAggregateRoot
 {
+    /// <summary>
+    /// Obtém o identificador único da raiz de agregado.
+    /// </summary>
     Guid Id { get; }
+    /// <summary>
+    /// Obtém a versão atual da raiz de agregado para controle de concorrência otimista.
+    /// </summary>
     int Version { get; }
 
+    /// <summary>
+    /// Retorna a coleção imutável de eventos de domínio ainda não confirmados no repositório de eventos.
+    /// </summary>
+    /// <returns>Coleção somente leitura com os eventos pendentes de persistência.</returns>
     IReadOnlyCollection<IEvent> GetUncommittedEvents();
+    /// <summary>
+    /// Limpa os eventos não confirmados após a persistência bem-sucedida.
+    /// </summary>
     void ClearUncommittedEvents();
+    /// <summary>
+    /// Reidrata o estado do agregado a partir de um histórico de eventos previamente persistidos.
+    /// </summary>
+    /// <param name="events">Sequência cronológica de eventos utilizada para recompor o estado do agregado.</param>
     void LoadFromHistory(IEnumerable<IEvent> events);
 }

--- a/src/Rewardly.Domain/Interfaces/v1/IEvent.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/IEvent.cs
@@ -1,10 +1,29 @@
 ﻿namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Representa um evento de domínio imutável, contendo dados de identificação,
+/// rastreabilidade temporal, versionamento e metadados de contexto.
+/// </summary>
 public interface IEvent
 {
+    /// <summary>
+    /// Obtém o identificador único do evento.
+    /// </summary>
     Guid EventId { get; }
+    /// <summary>
+    /// Obtém o identificador da raiz de agregado associada ao evento.
+    /// </summary>
     Guid AggregateId { get; }
+    /// <summary>
+    /// Obtém a data e hora de ocorrência do evento.
+    /// </summary>
     DateTime OccurredAt { get; }
+    /// <summary>
+    /// Obtém a versão do agregado correspondente ao momento de geração do evento.
+    /// </summary>
     int Version { get; }
+    /// <summary>
+    /// Obtém metadados adicionais do evento, como correlação, causalidade e origem.
+    /// </summary>
     IReadOnlyDictionary<string, object> Metadata { get; }
 }

--- a/src/Rewardly.Domain/Interfaces/v1/IEventStore.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/IEventStore.cs
@@ -9,13 +9,13 @@ public interface IEventStore
     /// Persiste os eventos não confirmados de um agregado, aplicando verificação de versão esperada.
     /// </summary>
     /// <param name="aggregateId">Identificador do agregado cujos eventos serão persistidos.</param>
-    /// <param name="expectedVerion">Versão esperada do agregado para validação de concorrência.</param>
+    /// <param name="expectedVersion">Versão esperada do agregado para validação de concorrência.</param>
     /// <param name="uncommittedEvents">Eventos pendentes de persistência.</param>
     /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
     /// <returns>Tarefa assíncrona que representa a conclusão da persistência.</returns>
     Task SaveAsync(
         Guid aggregateId,
-        int expectedVerion,
+        int expectedVersion,
         IEnumerable<IEvent> uncommittedEvents,
         CancellationToken cancellationToken);
     

--- a/src/Rewardly.Domain/Interfaces/v1/IEventStore.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/IEventStore.cs
@@ -1,13 +1,30 @@
 ﻿namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Define operações de persistência e recuperação de eventos em um armazenamento de eventos.
+/// </summary>
 public interface IEventStore
 {
+    /// <summary>
+    /// Persiste os eventos não confirmados de um agregado, aplicando verificação de versão esperada.
+    /// </summary>
+    /// <param name="aggregateId">Identificador do agregado cujos eventos serão persistidos.</param>
+    /// <param name="expectedVerion">Versão esperada do agregado para validação de concorrência.</param>
+    /// <param name="uncommittedEvents">Eventos pendentes de persistência.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Tarefa assíncrona que representa a conclusão da persistência.</returns>
     Task SaveAsync(
         Guid aggregateId,
         int expectedVerion,
         IEnumerable<IEvent> uncommittedEvents,
         CancellationToken cancellationToken);
     
+    /// <summary>
+    /// Recupera o histórico completo de eventos associado a um agregado.
+    /// </summary>
+    /// <param name="aggregateId">Identificador do agregado a ser reconstituído.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Coleção somente leitura com os eventos do agregado, em ordem de persistência.</returns>
     Task<IReadOnlyCollection<IEvent>> LoadAsync(
         Guid aggregateId, 
         CancellationToken cancellationToken);

--- a/src/Rewardly.Domain/Interfaces/v1/INotification.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/INotification.cs
@@ -2,12 +2,34 @@
 
 namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Define o contrato para coleta e consulta de notificações de domínio.
+/// </summary>
 public interface INotification
 {
+    /// <summary>
+    /// Obtém a coleção somente leitura de notificações registradas.
+    /// </summary>
     IReadOnlyCollection<Notification> Notifications { get; }
+    /// <summary>
+    /// Indica se há ao menos uma notificação registrada.
+    /// </summary>
     bool HasNotifications { get; }
 
+    /// <summary>
+    /// Adiciona uma notificação a partir de código e mensagem descritiva.
+    /// </summary>
+    /// <param name="code">Código identificador da notificação.</param>
+    /// <param name="message">Mensagem detalhada da notificação.</param>
     void AddNotification(string code, string message);
+    /// <summary>
+    /// Adiciona uma instância de notificação já construída.
+    /// </summary>
+    /// <param name="notification">Objeto de notificação a ser registrado.</param>
     void AddNotification(Notification notification);
+    /// <summary>
+    /// Adiciona um conjunto de notificações de uma única vez.
+    /// </summary>
+    /// <param name="notifications">Coleção de notificações a serem registradas.</param>
     void AddNotification(IEnumerable<Notification> notifications);
 }

--- a/src/Rewardly.Domain/Interfaces/v1/IRepository.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/IRepository.cs
@@ -1,7 +1,23 @@
 ﻿namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Define operações de acesso e persistência para agregados de domínio.
+/// </summary>
+/// <typeparam name="TAggregate">Tipo da raiz de agregado manipulada pelo repositório.</typeparam>
 public interface IRepository<TAggregate> where TAggregate : IAggregateRoot
 {
+    /// <summary>
+    /// Localiza um agregado pelo identificador informado.
+    /// </summary>
+    /// <param name="id">Identificador único do agregado.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Instância do agregado correspondente ao identificador fornecido.</returns>
     Task<TAggregate> FindOneAsync(Guid id, CancellationToken cancellationToken);
+    /// <summary>
+    /// Persiste o estado atual do agregado e seus eventos pendentes.
+    /// </summary>
+    /// <param name="account">Agregado a ser persistido.</param>
+    /// <param name="cancellationToken">Token para cancelamento cooperativo da operação assíncrona.</param>
+    /// <returns>Tarefa assíncrona que representa a conclusão da persistência.</returns>
     Task SaveAsync(TAggregate account, CancellationToken cancellationToken);
 }

--- a/src/Rewardly.Domain/Interfaces/v1/ISpecification.cs
+++ b/src/Rewardly.Domain/Interfaces/v1/ISpecification.cs
@@ -1,6 +1,15 @@
 ﻿namespace Rewardly.Domain.Interfaces.v1;
 
+/// <summary>
+/// Representa uma especificação de negócio para validação de objetos de domínio.
+/// </summary>
+/// <typeparam name="T">Tipo de objeto avaliado pela especificação.</typeparam>
 public interface ISpecification<T>
 {
+    /// <summary>
+    /// Avalia se o item informado satisfaz os critérios definidos pela especificação.
+    /// </summary>
+    /// <param name="item">Instância a ser validada.</param>
+    /// <returns><see langword="true"/> quando o item atende aos critérios; caso contrário, <see langword="false"/>.</returns>
     bool IsSatisfiedBy(T item);
 }


### PR DESCRIPTION
This pull request introduces a complete implementation of a CQRS command bus infrastructure in the application layer, along with improvements to domain interfaces and response types. The changes include new abstractions and concrete classes for command dispatching, command handler resolution, and command execution context, as well as dependency injection registration. Additionally, several domain interfaces have been enhanced with XML documentation for better maintainability and clarity.

The most important changes are:

### CQRS Command Bus Infrastructure

* Added a new command bus system with interfaces and implementations: `ICommandBus`, `CommandBus`, `ICommandHandler`, `ICommandHandlerResolver`, `CommandHandlerResolver`, and `CommandExecutionContext`, enabling decoupled command dispatching and handler resolution. [[1]](diffhunk://#diff-52c15bc6547e321f2a2b1ce953d89504a94614976b09f6cb782a3a281cfcc5f6R1-R28) [[2]](diffhunk://#diff-80bbfc2b6b456e65c6b63b3f2d0ffe39b1a1e31ce087093faca70411bb72ac68R1-R27) [[3]](diffhunk://#diff-41205a0920b8a3943d955358fb58d88cfe68dbda1fe4b6dcda97ad346aeef372R1-R32) [[4]](diffhunk://#diff-b7d41ba618ca17142ebfad023cb88d4e8bd556f61d2d910f4e82348720003075R1-R24) [[5]](diffhunk://#diff-67890f31347a1b0260e7bcc5d832595fcd25a87697b0463b5dcf890a26cde924R1-R37) [[6]](diffhunk://#diff-0e5fc4cca8ea3ca56fc410424c243cc9900195544250e5f50c97e1223248bd42R1-R19)
* Introduced a base command abstraction `CommandBase<TResponse>` implementing command metadata (`CorrelationId`, `CreatedAt`). [[1]](diffhunk://#diff-e340157e70acc85bc6851aaf8d157ea48209d6d481b3f7a1a0b72b326e77196aR1-R9) [[2]](diffhunk://#diff-c5c4a65474c66feb44ceb63b20b41fac163afaaebfbc1c8b0080138147b83146R1-R27)

### Dependency Injection

* Registered the new command bus services (`ICommandBus`, `CommandBus`, `ICommandHandlerResolver`, `CommandHandlerResolver`) in the application's IoC container (`ApplicationModule`). [[1]](diffhunk://#diff-36f0783870c9d5fb213aae33431d5fe05ea7eab73788d974b84505ba7fd6828fR2-R3) [[2]](diffhunk://#diff-36f0783870c9d5fb213aae33431d5fe05ea7eab73788d974b84505ba7fd6828fR14-R15)

### Response Type Improvements

* Refactored `ResponseBase<T>` to use private setters, enforce immutability, and provide static factory methods for success and failure responses.

### Domain Interface Enhancements

* Added comprehensive XML documentation to all domain interfaces, including `IAggregateRoot`, `IEvent`, `IEventStore`, `INotification`, `IRepository`, and `ISpecification`, clarifying their responsibilities and usage. [[1]](diffhunk://#diff-fbc7e2777281299f4c5f9aa723725d7b21f081a7c82874bbb741fb4d28591e45R3-R30) [[2]](diffhunk://#diff-4376c6d2d904f438cfe297a80e6c0c87a8b12e3b35399d019ac59710f7e099c5R3-R27) [[3]](diffhunk://#diff-24efc216de8d6d8432044b74141f7e802ace1b631a94b40831a59a2a54d2cbd9R3-R27) [[4]](diffhunk://#diff-86b2d4d9fbfe233fe9c2da9bd5e34acbc76185a4fd45d026ec7d9b35813b3132R5-R33) [[5]](diffhunk://#diff-4694a1bc7c7ed24863e9f909dd0afbc8a25b324de305183222645477b9fe0ff9R3-R21) [[6]](diffhunk://#diff-ea6596e1304a9a5f420e90af66b02b97da75f460a190201d87949b4f56b4e2c9R3-R13)